### PR TITLE
Add core case management scaffolding

### DIFF
--- a/app/Http/Controllers/API/CaseController.php
+++ b/app/Http/Controllers/API/CaseController.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Http\Controllers\API;
+
+use App\Http\Controllers\Controller;
+use App\Models\CaseFile;
+use Illuminate\Http\Request;
+
+class CaseController extends Controller
+{
+    public function index()
+    {
+        return CaseFile::with(['client','lawyer','court'])->get();
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'title' => 'required',
+            'description' => 'nullable',
+            'client_id' => 'required|exists:clients,id',
+            'lawyer_id' => 'required|exists:lawyers,id',
+            'court_id' => 'required|exists:courts,id',
+        ]);
+        return CaseFile::create($data);
+    }
+
+    public function show(CaseFile $case)
+    {
+        return $case->load(['client','lawyer','court','hearings']);
+    }
+
+    public function update(Request $request, CaseFile $case)
+    {
+        $data = $request->validate([
+            'title' => 'sometimes|required',
+            'description' => 'nullable',
+            'client_id' => 'sometimes|exists:clients,id',
+            'lawyer_id' => 'sometimes|exists:lawyers,id',
+            'court_id' => 'sometimes|exists:courts,id',
+        ]);
+        $case->update($data);
+        return $case;
+    }
+
+    public function destroy(CaseFile $case)
+    {
+        $case->delete();
+        return response()->noContent();
+    }
+}

--- a/app/Http/Controllers/API/ClientController.php
+++ b/app/Http/Controllers/API/ClientController.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Controllers\API;
+
+use App\Http\Controllers\Controller;
+use App\Models\Client;
+use Illuminate\Http\Request;
+
+class ClientController extends Controller
+{
+    public function index()
+    {
+        return Client::all();
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'name' => 'required',
+            'email' => 'required|email|unique:clients,email',
+            'phone' => 'nullable',
+        ]);
+        return Client::create($data);
+    }
+
+    public function show(Client $client)
+    {
+        return $client;
+    }
+
+    public function update(Request $request, Client $client)
+    {
+        $data = $request->validate([
+            'name' => 'sometimes|required',
+            'email' => 'sometimes|required|email|unique:clients,email,'.$client->id,
+            'phone' => 'nullable',
+        ]);
+        $client->update($data);
+        return $client;
+    }
+
+    public function destroy(Client $client)
+    {
+        $client->delete();
+        return response()->noContent();
+    }
+}

--- a/app/Http/Controllers/API/CourtController.php
+++ b/app/Http/Controllers/API/CourtController.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Controllers\API;
+
+use App\Http\Controllers\Controller;
+use App\Models\Court;
+use Illuminate\Http\Request;
+
+class CourtController extends Controller
+{
+    public function index()
+    {
+        return Court::all();
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'name' => 'required',
+            'location' => 'nullable',
+        ]);
+        return Court::create($data);
+    }
+
+    public function show(Court $court)
+    {
+        return $court;
+    }
+
+    public function update(Request $request, Court $court)
+    {
+        $data = $request->validate([
+            'name' => 'sometimes|required',
+            'location' => 'nullable',
+        ]);
+        $court->update($data);
+        return $court;
+    }
+
+    public function destroy(Court $court)
+    {
+        $court->delete();
+        return response()->noContent();
+    }
+}

--- a/app/Http/Controllers/API/HearingController.php
+++ b/app/Http/Controllers/API/HearingController.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Controllers\API;
+
+use App\Http\Controllers\Controller;
+use App\Models\Hearing;
+use Illuminate\Http\Request;
+
+class HearingController extends Controller
+{
+    public function index()
+    {
+        return Hearing::with('case')->get();
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'case_id' => 'required|exists:cases,id',
+            'scheduled_at' => 'required|date',
+            'notes' => 'nullable',
+        ]);
+        return Hearing::create($data);
+    }
+
+    public function show(Hearing $hearing)
+    {
+        return $hearing->load('case');
+    }
+
+    public function update(Request $request, Hearing $hearing)
+    {
+        $data = $request->validate([
+            'case_id' => 'sometimes|exists:cases,id',
+            'scheduled_at' => 'sometimes|date',
+            'notes' => 'nullable',
+        ]);
+        $hearing->update($data);
+        return $hearing;
+    }
+
+    public function destroy(Hearing $hearing)
+    {
+        $hearing->delete();
+        return response()->noContent();
+    }
+}

--- a/app/Http/Controllers/API/LawyerController.php
+++ b/app/Http/Controllers/API/LawyerController.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Controllers\API;
+
+use App\Http\Controllers\Controller;
+use App\Models\Lawyer;
+use Illuminate\Http\Request;
+
+class LawyerController extends Controller
+{
+    public function index()
+    {
+        return Lawyer::all();
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'name' => 'required',
+            'email' => 'required|email|unique:lawyers,email',
+            'phone' => 'nullable',
+        ]);
+        return Lawyer::create($data);
+    }
+
+    public function show(Lawyer $lawyer)
+    {
+        return $lawyer;
+    }
+
+    public function update(Request $request, Lawyer $lawyer)
+    {
+        $data = $request->validate([
+            'name' => 'sometimes|required',
+            'email' => 'sometimes|required|email|unique:lawyers,email,'.$lawyer->id,
+            'phone' => 'nullable',
+        ]);
+        $lawyer->update($data);
+        return $lawyer;
+    }
+
+    public function destroy(Lawyer $lawyer)
+    {
+        $lawyer->delete();
+        return response()->noContent();
+    }
+}

--- a/app/Http/Controllers/CaseController.php
+++ b/app/Http/Controllers/CaseController.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\CaseFile;
+use Illuminate\Http\Request;
+
+class CaseController extends Controller
+{
+    public function index()
+    {
+        $cases = CaseFile::with(['client','lawyer','court'])->get();
+        return view('cases.index', compact('cases'));
+    }
+
+    public function show(CaseFile $case)
+    {
+        return view('cases.show', compact('case'));
+    }
+}

--- a/app/Models/CaseFile.php
+++ b/app/Models/CaseFile.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class CaseFile extends Model
+{
+    use HasFactory;
+
+    protected $table = 'cases';
+
+    protected $fillable = [
+        'title',
+        'description',
+        'client_id',
+        'lawyer_id',
+        'court_id',
+    ];
+
+    public function client()
+    {
+        return $this->belongsTo(Client::class);
+    }
+
+    public function lawyer()
+    {
+        return $this->belongsTo(Lawyer::class);
+    }
+
+    public function court()
+    {
+        return $this->belongsTo(Court::class);
+    }
+
+    public function hearings()
+    {
+        return $this->hasMany(Hearing::class, 'case_id');
+    }
+}

--- a/app/Models/Client.php
+++ b/app/Models/Client.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Client extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'email',
+        'phone',
+    ];
+
+    public function cases()
+    {
+        return $this->hasMany(CaseFile::class, 'client_id');
+    }
+}

--- a/app/Models/Court.php
+++ b/app/Models/Court.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Court extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'location',
+    ];
+
+    public function cases()
+    {
+        return $this->hasMany(CaseFile::class, 'court_id');
+    }
+}

--- a/app/Models/Hearing.php
+++ b/app/Models/Hearing.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Hearing extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'case_id',
+        'scheduled_at',
+        'notes',
+    ];
+
+    public function case()
+    {
+        return $this->belongsTo(CaseFile::class, 'case_id');
+    }
+}

--- a/app/Models/Lawyer.php
+++ b/app/Models/Lawyer.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Lawyer extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'email',
+        'phone',
+    ];
+
+    public function cases()
+    {
+        return $this->hasMany(CaseFile::class, 'lawyer_id');
+    }
+}

--- a/database/factories/CaseFileFactory.php
+++ b/database/factories/CaseFileFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\CaseFile;
+use App\Models\Client;
+use App\Models\Lawyer;
+use App\Models\Court;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class CaseFileFactory extends Factory
+{
+    protected $model = CaseFile::class;
+
+    public function definition(): array
+    {
+        return [
+            'title' => $this->faker->sentence(),
+            'description' => $this->faker->paragraph(),
+            'client_id' => Client::factory(),
+            'lawyer_id' => Lawyer::factory(),
+            'court_id' => Court::factory(),
+        ];
+    }
+}

--- a/database/factories/ClientFactory.php
+++ b/database/factories/ClientFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Client;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ClientFactory extends Factory
+{
+    protected $model = Client::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->name(),
+            'email' => $this->faker->unique()->safeEmail(),
+            'phone' => $this->faker->phoneNumber(),
+        ];
+    }
+}

--- a/database/factories/CourtFactory.php
+++ b/database/factories/CourtFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Court;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class CourtFactory extends Factory
+{
+    protected $model = Court::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->company(),
+            'location' => $this->faker->address(),
+        ];
+    }
+}

--- a/database/factories/HearingFactory.php
+++ b/database/factories/HearingFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Hearing;
+use App\Models\CaseFile;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class HearingFactory extends Factory
+{
+    protected $model = Hearing::class;
+
+    public function definition(): array
+    {
+        return [
+            'case_id' => CaseFile::factory(),
+            'scheduled_at' => $this->faker->dateTimeBetween('+1 days', '+1 month'),
+            'notes' => $this->faker->sentence(),
+        ];
+    }
+}

--- a/database/factories/LawyerFactory.php
+++ b/database/factories/LawyerFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Lawyer;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class LawyerFactory extends Factory
+{
+    protected $model = Lawyer::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->name(),
+            'email' => $this->faker->unique()->safeEmail(),
+            'phone' => $this->faker->phoneNumber(),
+        ];
+    }
+}

--- a/database/migrations/2024_01_01_000001_create_clients_table.php
+++ b/database/migrations/2024_01_01_000001_create_clients_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('clients', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('phone')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('clients');
+    }
+};

--- a/database/migrations/2024_01_01_000002_create_lawyers_table.php
+++ b/database/migrations/2024_01_01_000002_create_lawyers_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('lawyers', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('phone')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('lawyers');
+    }
+};

--- a/database/migrations/2024_01_01_000003_create_courts_table.php
+++ b/database/migrations/2024_01_01_000003_create_courts_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('courts', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('location')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('courts');
+    }
+};

--- a/database/migrations/2024_01_01_000004_create_cases_table.php
+++ b/database/migrations/2024_01_01_000004_create_cases_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('cases', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->text('description')->nullable();
+            $table->foreignId('client_id')->constrained('clients');
+            $table->foreignId('lawyer_id')->constrained('lawyers');
+            $table->foreignId('court_id')->constrained('courts');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('cases');
+    }
+};

--- a/database/migrations/2024_01_01_000005_create_hearings_table.php
+++ b/database/migrations/2024_01_01_000005_create_hearings_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('hearings', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('case_id')->constrained('cases');
+            $table->dateTime('scheduled_at');
+            $table->text('notes')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('hearings');
+    }
+};

--- a/resources/views/cases/index.blade.php
+++ b/resources/views/cases/index.blade.php
@@ -1,0 +1,10 @@
+@extends('layout')
+
+@section('content')
+<h1>Cases</h1>
+<ul>
+    @foreach($cases as $case)
+        <li><a href="{{ route('cases.show', $case) }}">{{ $case->title }}</a></li>
+    @endforeach
+</ul>
+@endsection

--- a/resources/views/cases/show.blade.php
+++ b/resources/views/cases/show.blade.php
@@ -1,0 +1,15 @@
+@extends('layout')
+
+@section('content')
+<h1>{{ $case->title }}</h1>
+<p>{{ $case->description }}</p>
+<p>Client: {{ $case->client->name }}</p>
+<p>Lawyer: {{ $case->lawyer->name }}</p>
+<p>Court: {{ $case->court->name }}</p>
+<h2>Hearings</h2>
+<ul>
+    @foreach($case->hearings as $hearing)
+        <li>{{ $hearing->scheduled_at }} - {{ $hearing->notes }}</li>
+    @endforeach
+</ul>
+@endsection

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>eLawyer</title>
+</head>
+<body>
+    @yield('content')
+</body>
+</html>

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,16 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\API\{
+    ClientController,
+    LawyerController,
+    CourtController,
+    CaseController,
+    HearingController
+};
+
+Route::apiResource('clients', ClientController::class);
+Route::apiResource('lawyers', LawyerController::class);
+Route::apiResource('courts', CourtController::class);
+Route::apiResource('cases', CaseController::class);
+Route::apiResource('hearings', HearingController::class);

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,0 +1,10 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\CaseController;
+
+Route::get('/', function () {
+    return redirect()->route('cases.index');
+});
+
+Route::resource('cases', CaseController::class)->only(['index','show']);

--- a/tracker.md
+++ b/tracker.md
@@ -1,0 +1,3 @@
+# Progress Tracker
+
+- [x] Core Case/Client/Court Modules


### PR DESCRIPTION
## Summary
- scaffold Case, Client, Lawyer, Court, Hearing models
- add migrations and factories for each model
- create API controllers and routes
- create simple web views for cases
- track completion of core modules

## Testing
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684201fd24c48326b88df7e2aead5ea6